### PR TITLE
Fix country names starting with 'The'

### DIFF
--- a/client.go
+++ b/client.go
@@ -125,7 +125,9 @@ func (c *Okta) printEvents(events []*okta.LogEvent) {
 	for _, event := range events {
 		if event.Client != nil {
 			if event.Client.GeographicalContext != nil {
-				country := c.countryMapper.MapByName(event.Client.GeographicalContext.Country)
+				country := c.countryMapper.MapByName(
+					strings.TrimPrefix(event.Client.GeographicalContext.Country, "The "),
+				)
 				if country != nil {
 					event.Client.GeographicalContext.Country = country.Alpha2
 				}


### PR DESCRIPTION
We found it while checking logs that countries like "The Netherlands" are not properly processed by the `country_mapper` package, hence the fix.