### PR TITLE
Fix zizmor cache-poisoning findings and bump Go to 1.26

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,8 +22,8 @@ jobs:
       - name: Set up Go 1.22
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
-          cache: true
+          go-version: "1.26"
+          cache: false
       - name: Build and release binaries
         run: make build-release
       - name: Set up QEMU

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,21 +27,21 @@ jobs:
       - name: Build and release binaries
         run: make build-release
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: Sign in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: grafana/okta-logs-collector
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -50,18 +50,18 @@ jobs:
           sbom: true
           tags: ${{ steps.meta.outputs.tags }}
       - name: Scan Docker image with Syft and generate SBOM
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@57aae528053a48a3f6235f2d9461b05fbcb7366d # v0
         with:
           image: docker:grafana/okta-logs-collector:${{ github.ref_name }}
           format: cyclonedx-json
           output-file: okta-logs-collector-image-${{ github.ref_name }}.cyclonedx.json
       - name: Scan source code and generate SBOM
-        uses: CycloneDX/gh-gomod-generate-sbom@v2
+        uses: CycloneDX/gh-gomod-generate-sbom@efc74245d6802c8cefd925620515442756c70d8f # v2
         with:
           version: v1
           args: mod -json -licenses -output okta-logs-collector-source-${{ github.ref_name }}.cyclonedx.json
       - name: Create release and add artifacts
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
           files: |
             dist/*.tar.gz

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,14 +41,14 @@ jobs:
           cache: false
 
       - name: Lint code with golangci-lint 🚨
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@d6238b002a20823d52840fda27e2d4891c5952dc # v4
         with:
           version: "v1.59"
           skip-pkg-cache: true
           install-mode: "goinstall"
 
       - name: Lint Dockerfile with hadolint 🚨
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf # v3.1.0
         with:
           dockerfile: Dockerfile
 
@@ -56,6 +56,6 @@ jobs:
         run: go test -p 1 -cover -covermode atomic -coverprofile=profile.cov -v ./...
 
       - name: Report coverage to coveralls 📈
-        uses: shogo82148/actions-goveralls@v1
+        uses: shogo82148/actions-goveralls@25f5320d970fb565100cf1993ada29be1bb196a1 # v1
         with:
           path-to-profile: profile.cov

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,8 @@ jobs:
       - name: Install Go 🧑‍💻
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.26"
+          cache: false
 
       - name: Lint code with golangci-lint 🚨
         uses: golangci/golangci-lint-action@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Lint code with golangci-lint 🚨
         uses: golangci/golangci-lint-action@d6238b002a20823d52840fda27e2d4891c5952dc # v4
         with:
-          version: "v1.59"
+          version: "v1.59.1"
           skip-pkg-cache: true
           install-mode: "goinstall"
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/okta-logs-collector
 
-go 1.22
+go 1.26
 
 require (
 	github.com/jarcoal/httpmock v1.3.1


### PR DESCRIPTION
## Summary

- Disable Go module cache (`cache: false`) in `actions/setup-go` steps in both `release.yaml` and `test.yaml` to resolve zizmor `cache-poisoning` high-severity findings
- Bump Go version from 1.22 to 1.26 in workflows and `go.mod`

## Test plan

- [ ] Verify zizmor checks pass on this branch
- [ ] Verify the test workflow runs successfully with Go 1.26
- [ ] Verify the release workflow builds successfully with Go 1.26