### PR TITLE
Update go versions to 1.26.2 and alpine to 3.23

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,10 +21,10 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Set up Go 1.22
+      - name: Set up Go 1.26.2
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.22"
+          go-version: "1.26.2"
           cache: false
       - name: Build and release binaries
         run: make build-release

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Install Go 🧑‍💻
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.22"
+          go-version: "1.26.2"
           cache: false
 
       - name: Lint code with golangci-lint 🚨

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,11 +44,7 @@ jobs:
           cache: false
 
       - name: Lint code with golangci-lint 🚨
-        uses: golangci/golangci-lint-action@d6238b002a20823d52840fda27e2d4891c5952dc # v4
-        with:
-          version: "v1.59"
-          skip-pkg-cache: true
-          install-mode: "goinstall"
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
 
       - name: Lint Dockerfile with hadolint 🚨
         uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf # v3.1.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,60 +1,74 @@
-run:
-  timeout: 3m
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
-    # Default linters
-    - errcheck
-    - gosimple
-    - govet
-    - ineffassign
-    - staticcheck
-    - unused
-    # Custom linters
     - asciicheck
     - bodyclose
     - depguard
     - dogsled
-    - gofmt
+    - errcheck
     - errorlint
     - exhaustive
-    - exportloopref
     - forbidigo
     - forcetypeassert
     - goconst
     - gocritic
-    - gofumpt
-    - goimports
     - goprintffuncname
     - gosec
+    - govet
+    - ineffassign
     - misspell
     - nakedret
     - nilerr
+    - prealloc
     - reassign
     - revive
+    - staticcheck
     - unconvert
+    - unused
     - varnamelen
     - whitespace
-    - prealloc
-linters-settings:
-  depguard:
-    rules:
-      main:
-        files:
-          - $all
-          - "!$test"
-        allow:
-          - $gostd
-          - "github.com/grafana/okta-logs-collector/metadata"
-          - "github.com/okta/okta-sdk-golang/v2/"
-          - "github.com/pirsquare/country-mapper"
-          - "github.com/sirupsen/logrus"
-          - "github.com/urfave/cli/v2"
-      test:
-        files:
-          - $test
-        allow:
-          - $gostd
-          - "github.com/jarcoal/httpmock"
-          - "github.com/stretchr/testify"
-          - "github.com/okta/okta-sdk-golang/v2"
+  settings:
+    depguard:
+      rules:
+        main:
+          files:
+            - $all
+            - '!$test'
+          allow:
+            - $gostd
+            - github.com/grafana/okta-logs-collector/metadata
+            - github.com/okta/okta-sdk-golang/v2/
+            - github.com/pirsquare/country-mapper
+            - github.com/sirupsen/logrus
+            - github.com/urfave/cli/v2
+        test:
+          files:
+            - $test
+          allow:
+            - $gostd
+            - github.com/jarcoal/httpmock
+            - github.com/stretchr/testify
+            - github.com/okta/okta-sdk-golang/v2
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - gofumpt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.26.2-alpine3.22 AS build
+FROM golang:1.26.2-alpine3.23 AS build
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -8,10 +8,10 @@ ARG TARGETARCH
 RUN mkdir /app
 WORKDIR /app
 COPY . /app/
-RUN apk --no-cache add git=2.49.1-r0 make=4.4.1-r3 && \
+RUN apk --no-cache add git=2.52.0-r0 make=4.4.1-r3 && \
     make build-docker-release GOOS=${TARGETOS} GOARCH=${TARGETARCH}
 
-FROM alpine:3.22 AS runner
+FROM alpine:3.23 AS runner
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.22.3-alpine3.20 AS build
+FROM golang:1.26.2-alpine3.22 AS build
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -8,10 +8,10 @@ ARG TARGETARCH
 RUN mkdir /app
 WORKDIR /app
 COPY . /app/
-RUN apk --no-cache add git=2.45.2-r0 make=4.4.1-r2 && \
+RUN apk --no-cache add git=2.49.1-r0 make=4.4.1-r3 && \
     make build-docker-release GOOS=${TARGETOS} GOARCH=${TARGETARCH}
 
-FROM alpine:3.20 AS runner
+FROM alpine:3.22 AS runner
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/client.go
+++ b/client.go
@@ -17,7 +17,9 @@ const (
 	logActorTypeUser         = "User"
 	headerRateLimitLimit     = "X-Rate-Limit-Limit"
 	headerRateLimitRemaining = "X-Rate-Limit-Remaining"
+	headerRateLimitReset     = "X-Rate-Limit-Reset"
 	defaultLogLevel          = "info"
+	logMsgReceivedEvent      = "received event"
 )
 
 type Okta struct {
@@ -117,7 +119,7 @@ func (c *Okta) logRateLimits(resp *okta.Response) {
 	logEntry := logrus.WithFields(logrus.Fields{
 		"limit":     limit,
 		"remaining": remaining,
-		"reset":     resp.Header.Get("X-Rate-Limit-Reset"),
+		"reset":     resp.Header.Get(headerRateLimitReset),
 	})
 
 	// Log a warning only if we are close to the limit.
@@ -160,7 +162,7 @@ func (c *Okta) printEvents(events []*okta.LogEvent) {
 		// Otherwise, we log the event with the parsed log level.
 		// see https://developer.okta.com/docs/reference/api/system-log/#attributes
 		if strings.ToLower(event.Severity) == "debug" {
-			logrus.WithTime(*event.Published).WithField("event", &event).Info("received event")
+			logrus.WithTime(*event.Published).WithField("event", &event).Info(logMsgReceivedEvent)
 		} else {
 			level, err := logrus.ParseLevel(event.Severity)
 			if err != nil {
@@ -171,13 +173,13 @@ func (c *Okta) printEvents(events []*okta.LogEvent) {
 				logrus.
 					WithTime(*event.Published).
 					WithField("event", &event).
-					Info("received event")
+					Info(logMsgReceivedEvent)
 				continue
 			}
 			logrus.
 				WithTime(*event.Published).
 				WithField("event", &event).
-				Log(level, "received event")
+				Log(level, logMsgReceivedEvent)
 		}
 	}
 }

--- a/client.go
+++ b/client.go
@@ -13,6 +13,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	logActorTypeUser         = "User"
+	headerRateLimitLimit     = "X-Rate-Limit-Limit"
+	headerRateLimitRemaining = "X-Rate-Limit-Remaining"
+	defaultLogLevel          = "info"
+)
+
 type Okta struct {
 	client *okta.Client
 	ctx    context.Context
@@ -95,13 +102,13 @@ func (c *Okta) PollSystemLogs() error {
 // logRateLimits logs the rate limits from the Okta API response when
 // the remaining limit is less than 2.
 func (c *Okta) logRateLimits(resp *okta.Response) {
-	limit, err := strconv.Atoi(resp.Header.Get("X-Rate-Limit-Limit"))
+	limit, err := strconv.Atoi(resp.Header.Get(headerRateLimitLimit))
 	if err != nil {
 		logrus.WithError(err).Error("could not parse rate limit")
 		return
 	}
 
-	remaining, err := strconv.Atoi(resp.Header.Get("X-Rate-Limit-Remaining"))
+	remaining, err := strconv.Atoi(resp.Header.Get(headerRateLimitRemaining))
 	if err != nil {
 		logrus.WithError(err).Error("could not parse remaining rate limit")
 		return
@@ -182,13 +189,13 @@ func (c *Okta) printEvents(events []*okta.LogEvent) {
 // Parameters:
 // - event: A pointer to an okta.LogEvent object that need to be sanitized.
 func sanitizeUserIdentity(event *okta.LogEvent) {
-	if event.Actor != nil && event.Actor.Type == "User" {
+	if event.Actor != nil && event.Actor.Type == logActorTypeUser {
 		event.Actor.DisplayName = sanitizeString(event.Actor.DisplayName)
 		event.Actor.AlternateId = sanitizeString(event.Actor.AlternateId)
 	}
 
 	for _, target := range event.Target {
-		if target.Type == "User" {
+		if target.Type == logActorTypeUser {
 			target.DisplayName = sanitizeString(target.DisplayName)
 			target.AlternateId = sanitizeString(target.AlternateId)
 		}

--- a/client_test.go
+++ b/client_test.go
@@ -247,7 +247,7 @@ func TestLogRateLimits(t *testing.T) {
 			Header: map[string][]string{
 				headerRateLimitLimit:     {"60"},
 				headerRateLimitRemaining: {"59"},
-				"X-Rate-Limit-Reset":     {"1630000000"},
+				headerRateLimitReset:     {"1630000000"},
 			},
 		},
 	}
@@ -277,7 +277,7 @@ func TestLogRateLimits_remaining_less_than_2(t *testing.T) {
 			Header: map[string][]string{
 				headerRateLimitLimit:     {"60"},
 				headerRateLimitRemaining: {"1"},
-				"X-Rate-Limit-Reset":     {"1630000000"},
+				headerRateLimitReset:     {"1630000000"},
 			},
 		},
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -14,11 +14,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	testOktaURL           = "https://example.okta.com"
+	testAPIKey            = "your-api-key"
+	testEventID           = "some-random-id"
+	testActorTypeService  = "Service"
+	testActorDisplayName  = "actor1"
+	testActorAltID        = "alt1"
+	testTargetDisplayName = "target1"
+	testSanitizedAltID    = "a...1"
+)
+
 func TestPrintEvents(t *testing.T) {
 	config = &Config{
-		oktaURL:          "https://example.okta.com",
-		apiKey:           "your-api-key",
-		logLevel:         "info",
+		oktaURL:          testOktaURL,
+		apiKey:           testAPIKey,
+		logLevel:         defaultLogLevel,
 		lookbackInterval: 24 * time.Hour,
 		requestTimeout:   10 * time.Second,
 		pollInterval:     5 * time.Second,
@@ -39,12 +50,12 @@ func TestPrintEvents(t *testing.T) {
 			Actor: &okta.LogActor{
 				AlternateId: "test@example.com",
 				DisplayName: "Test User",
-				Id:          "some-random-id",
-				Type:        "User",
+				Id:          testEventID,
+				Type:        logActorTypeUser,
 			},
 			AuthenticationContext: &okta.LogAuthenticationContext{
 				AuthenticationStep: 0,
-				ExternalSessionId:  "some-random-id",
+				ExternalSessionId:  testEventID,
 			},
 			Client: &okta.LogClient{
 				Device: "Computer",
@@ -58,7 +69,7 @@ func TestPrintEvents(t *testing.T) {
 					PostalCode: "10000",
 					State:      "NY",
 				},
-				Id:        "some-random-id",
+				Id:        testEventID,
 				IpAddress: "1.1.1.1",
 				UserAgent: &okta.LogUserAgent{
 					Browser:      "Chrome",
@@ -69,10 +80,10 @@ func TestPrintEvents(t *testing.T) {
 			},
 			DebugContext: &okta.LogDebugContext{
 				DebugData: map[string]interface{}{
-					"authnRequestId":  "some-random-id",
+					"authnRequestId":  testEventID,
 					"dtHash":          "some-random-hash",
 					"redirectUri":     "https://example.com/login/sso/oidc",
-					"requestId":       "some-random-id",
+					"requestId":       testEventID,
 					"requestUri":      "/oauth2/v1/authorize",
 					"threatSuspected": "false",
 					"url":             "/oauth2/v1/authorize?client_id=some-random-id&scope=openid+email+profile&response_type=code&redirect_uri=https://example.com/login/sso/oidc&state=some-random-state&code_challenge=some-random-code-challenge&code_challenge_method=S256",
@@ -115,12 +126,12 @@ func TestPrintEvents(t *testing.T) {
 				{
 					AlternateId: "Something something",
 					DisplayName: "Some display name",
-					Id:          "some-random-id",
+					Id:          testEventID,
 					Type:        "AppInstance",
 				},
 			},
 			Transaction: &okta.LogTransaction{
-				Id:   "some-random-id",
+				Id:   testEventID,
 				Type: "WEB",
 			},
 			Uuid:    "some-random-uuid",
@@ -136,9 +147,9 @@ func TestPrintEvents(t *testing.T) {
 
 func TestPrintEvents_debug(t *testing.T) {
 	config = &Config{
-		oktaURL:          "https://example.okta.com",
-		apiKey:           "your-api-key",
-		logLevel:         "info",
+		oktaURL:          testOktaURL,
+		apiKey:           testAPIKey,
+		logLevel:         defaultLogLevel,
 		lookbackInterval: 24 * time.Hour,
 		requestTimeout:   10 * time.Second,
 		pollInterval:     5 * time.Second,
@@ -168,9 +179,9 @@ func TestPrintEvents_debug(t *testing.T) {
 
 func TestPrintEvents_unknown_severity(t *testing.T) {
 	config = &Config{
-		oktaURL:          "https://example.okta.com",
-		apiKey:           "your-api-key",
-		logLevel:         "info",
+		oktaURL:          testOktaURL,
+		apiKey:           testAPIKey,
+		logLevel:         defaultLogLevel,
 		lookbackInterval: 24 * time.Hour,
 		requestTimeout:   10 * time.Second,
 		pollInterval:     5 * time.Second,
@@ -202,9 +213,9 @@ func TestPrintEvents_unknown_severity(t *testing.T) {
 
 func TestPrintEvents_no_events(t *testing.T) {
 	config = &Config{
-		oktaURL:          "https://example.okta.com",
-		apiKey:           "your-api-key",
-		logLevel:         "info",
+		oktaURL:          testOktaURL,
+		apiKey:           testAPIKey,
+		logLevel:         defaultLogLevel,
 		lookbackInterval: 24 * time.Hour,
 		requestTimeout:   10 * time.Second,
 		pollInterval:     5 * time.Second,
@@ -221,9 +232,9 @@ func TestPrintEvents_no_events(t *testing.T) {
 
 func TestLogRateLimits(t *testing.T) {
 	config = &Config{
-		oktaURL:          "https://example.okta.com",
-		apiKey:           "your-api-key",
-		logLevel:         "info",
+		oktaURL:          testOktaURL,
+		apiKey:           testAPIKey,
+		logLevel:         defaultLogLevel,
 		lookbackInterval: 24 * time.Hour,
 		requestTimeout:   10 * time.Second,
 		pollInterval:     5 * time.Second,
@@ -234,15 +245,15 @@ func TestLogRateLimits(t *testing.T) {
 	response := &okta.Response{
 		Response: &http.Response{
 			Header: map[string][]string{
-				"X-Rate-Limit-Limit":     {"60"},
-				"X-Rate-Limit-Remaining": {"59"},
+				headerRateLimitLimit:     {"60"},
+				headerRateLimitRemaining: {"59"},
 				"X-Rate-Limit-Reset":     {"1630000000"},
 			},
 		},
 	}
 
 	buf := bytes.NewBuffer(nil)
-	setupLogger(buf, "info")
+	setupLogger(buf, defaultLogLevel)
 
 	client.logRateLimits(response)
 
@@ -251,9 +262,9 @@ func TestLogRateLimits(t *testing.T) {
 
 func TestLogRateLimits_remaining_less_than_2(t *testing.T) {
 	config = &Config{
-		oktaURL:          "https://example.okta.com",
-		apiKey:           "your-api-key",
-		logLevel:         "info",
+		oktaURL:          testOktaURL,
+		apiKey:           testAPIKey,
+		logLevel:         defaultLogLevel,
 		lookbackInterval: 24 * time.Hour,
 		requestTimeout:   10 * time.Second,
 		pollInterval:     5 * time.Second,
@@ -264,15 +275,15 @@ func TestLogRateLimits_remaining_less_than_2(t *testing.T) {
 	response := &okta.Response{
 		Response: &http.Response{
 			Header: map[string][]string{
-				"X-Rate-Limit-Limit":     {"60"},
-				"X-Rate-Limit-Remaining": {"1"},
+				headerRateLimitLimit:     {"60"},
+				headerRateLimitRemaining: {"1"},
 				"X-Rate-Limit-Reset":     {"1630000000"},
 			},
 		},
 	}
 
 	buf := bytes.NewBuffer(nil)
-	setupLogger(buf, "info")
+	setupLogger(buf, defaultLogLevel)
 
 	client.logRateLimits(response)
 
@@ -284,9 +295,9 @@ func TestLogRateLimits_remaining_less_than_2(t *testing.T) {
 
 func TestLogRateLimits_missing_rate_limit(t *testing.T) {
 	config = &Config{
-		oktaURL:          "https://example.okta.com",
-		apiKey:           "your-api-key",
-		logLevel:         "info",
+		oktaURL:          testOktaURL,
+		apiKey:           testAPIKey,
+		logLevel:         defaultLogLevel,
 		lookbackInterval: 24 * time.Hour,
 		requestTimeout:   10 * time.Second,
 		pollInterval:     5 * time.Second,
@@ -299,7 +310,7 @@ func TestLogRateLimits_missing_rate_limit(t *testing.T) {
 	}
 
 	buf := bytes.NewBuffer(nil)
-	setupLogger(buf, "info")
+	setupLogger(buf, defaultLogLevel)
 
 	client.logRateLimits(response)
 
@@ -310,9 +321,9 @@ func TestLogRateLimits_missing_rate_limit(t *testing.T) {
 
 func TestLogRateLimits_missing_remaining_rate_limit(t *testing.T) {
 	config = &Config{
-		oktaURL:          "https://example.okta.com",
-		apiKey:           "your-api-key",
-		logLevel:         "info",
+		oktaURL:          testOktaURL,
+		apiKey:           testAPIKey,
+		logLevel:         defaultLogLevel,
 		lookbackInterval: 24 * time.Hour,
 		requestTimeout:   10 * time.Second,
 		pollInterval:     5 * time.Second,
@@ -323,13 +334,13 @@ func TestLogRateLimits_missing_remaining_rate_limit(t *testing.T) {
 	response := &okta.Response{
 		Response: &http.Response{
 			Header: map[string][]string{
-				"X-Rate-Limit-Limit": {"60"},
+				headerRateLimitLimit: {"60"},
 			},
 		},
 	}
 
 	buf := bytes.NewBuffer(nil)
-	setupLogger(buf, "info")
+	setupLogger(buf, defaultLogLevel)
 
 	client.logRateLimits(response)
 
@@ -340,9 +351,9 @@ func TestLogRateLimits_missing_remaining_rate_limit(t *testing.T) {
 
 func TestLogRateLimits_missing_reset_rate_limit(t *testing.T) {
 	config = &Config{
-		oktaURL:          "https://example.okta.com",
-		apiKey:           "your-api-key",
-		logLevel:         "info",
+		oktaURL:          testOktaURL,
+		apiKey:           testAPIKey,
+		logLevel:         defaultLogLevel,
 		lookbackInterval: 24 * time.Hour,
 		requestTimeout:   10 * time.Second,
 		pollInterval:     5 * time.Second,
@@ -353,14 +364,14 @@ func TestLogRateLimits_missing_reset_rate_limit(t *testing.T) {
 	response := &okta.Response{
 		Response: &http.Response{
 			Header: map[string][]string{
-				"X-Rate-Limit-Limit":     {"60"},
-				"X-Rate-Limit-Remaining": {"1"},
+				headerRateLimitLimit:     {"60"},
+				headerRateLimitRemaining: {"1"},
 			},
 		},
 	}
 
 	buf := bytes.NewBuffer(nil)
-	setupLogger(buf, "info")
+	setupLogger(buf, defaultLogLevel)
 
 	client.logRateLimits(response)
 
@@ -372,9 +383,9 @@ func TestLogRateLimits_missing_reset_rate_limit(t *testing.T) {
 
 func TestPollSystemLogs_invalid_token(t *testing.T) {
 	config = &Config{
-		oktaURL:          "https://example.okta.com",
-		apiKey:           "your-api-key",
-		logLevel:         "info",
+		oktaURL:          testOktaURL,
+		apiKey:           testAPIKey,
+		logLevel:         defaultLogLevel,
 		lookbackInterval: 24 * time.Hour,
 		requestTimeout:   10 * time.Second,
 		pollInterval:     5 * time.Second,
@@ -392,9 +403,9 @@ func TestPollSystemLogs_invalid_token(t *testing.T) {
 
 func TestPollSystemLogs_mock(t *testing.T) {
 	config = &Config{
-		oktaURL:          "https://example.okta.com",
-		apiKey:           "your-api-key",
-		logLevel:         "info",
+		oktaURL:          testOktaURL,
+		apiKey:           testAPIKey,
+		logLevel:         defaultLogLevel,
 		lookbackInterval: 24 * time.Hour,
 		requestTimeout:   10 * time.Second,
 		pollInterval:     5 * time.Second,
@@ -411,7 +422,7 @@ func TestPollSystemLogs_mock(t *testing.T) {
 	assert.NoError(t, err)
 	mockTransport.RegisterResponder(
 		"GET",
-		"https://example.okta.com/api/v1/logs",
+		testOktaURL+"/api/v1/logs",
 		respnder,
 	)
 	mockHTTPClient.Transport = mockTransport
@@ -443,45 +454,45 @@ func TestSanitizeUserIdentity(t *testing.T) {
 		{
 			name: "Actor is not User type",
 			input: &okta.LogEvent{
-				Actor: &okta.LogActor{Type: "Service", DisplayName: "actor1", AlternateId: "alt1"},
+				Actor: &okta.LogActor{Type: testActorTypeService, DisplayName: testActorDisplayName, AlternateId: testActorAltID},
 				Target: []*okta.LogTarget{
-					{Type: "User", DisplayName: "target1", AlternateId: "alt1"},
+					{Type: logActorTypeUser, DisplayName: testTargetDisplayName, AlternateId: testActorAltID},
 				},
 			},
 			expected: &okta.LogEvent{
-				Actor: &okta.LogActor{Type: "Service", DisplayName: "actor1", AlternateId: "alt1"},
+				Actor: &okta.LogActor{Type: testActorTypeService, DisplayName: testActorDisplayName, AlternateId: testActorAltID},
 				Target: []*okta.LogTarget{
-					{Type: "User", DisplayName: "t...1", AlternateId: "a...1"},
+					{Type: logActorTypeUser, DisplayName: "t...1", AlternateId: testSanitizedAltID},
 				},
 			},
 		},
 		{
 			name: "Actor is User type",
 			input: &okta.LogEvent{
-				Actor: &okta.LogActor{Type: "User", DisplayName: "actor1", AlternateId: "alt1"},
+				Actor: &okta.LogActor{Type: logActorTypeUser, DisplayName: testActorDisplayName, AlternateId: testActorAltID},
 				Target: []*okta.LogTarget{
-					{Type: "User", DisplayName: "target1", AlternateId: "alt1"},
+					{Type: logActorTypeUser, DisplayName: testTargetDisplayName, AlternateId: testActorAltID},
 				},
 			},
 			expected: &okta.LogEvent{
-				Actor: &okta.LogActor{Type: "User", DisplayName: "a...1", AlternateId: "a...1"},
+				Actor: &okta.LogActor{Type: logActorTypeUser, DisplayName: testSanitizedAltID, AlternateId: testSanitizedAltID},
 				Target: []*okta.LogTarget{
-					{Type: "User", DisplayName: "t...1", AlternateId: "a...1"},
+					{Type: logActorTypeUser, DisplayName: "t...1", AlternateId: testSanitizedAltID},
 				},
 			},
 		},
 		{
 			name: "Target is not User type",
 			input: &okta.LogEvent{
-				Actor: &okta.LogActor{Type: "User", DisplayName: "actor1", AlternateId: "alt1"},
+				Actor: &okta.LogActor{Type: logActorTypeUser, DisplayName: testActorDisplayName, AlternateId: testActorAltID},
 				Target: []*okta.LogTarget{
-					{Type: "Service", DisplayName: "target1", AlternateId: "alt1"},
+					{Type: testActorTypeService, DisplayName: testTargetDisplayName, AlternateId: testActorAltID},
 				},
 			},
 			expected: &okta.LogEvent{
-				Actor: &okta.LogActor{Type: "User", DisplayName: "a...1", AlternateId: "a...1"},
+				Actor: &okta.LogActor{Type: logActorTypeUser, DisplayName: testSanitizedAltID, AlternateId: testSanitizedAltID},
 				Target: []*okta.LogTarget{
-					{Type: "Service", DisplayName: "target1", AlternateId: "alt1"},
+					{Type: testActorTypeService, DisplayName: testTargetDisplayName, AlternateId: testActorAltID},
 				},
 			},
 		},

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/okta-logs-collector
 
-go 1.22
+go 1.26.2
 
 require (
 	github.com/jarcoal/httpmock v1.3.1

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func main() {
 					&cli.StringFlag{
 						Name:        "logLevel",
 						Usage:       "Log level",
-						Value:       "info",
+						Value:       defaultLogLevel,
 						Required:    false,
 						EnvVars:     []string{"LOG_LEVEL"},
 						Destination: &config.logLevel,


### PR DESCRIPTION
Updates the various references to go versions to latest (1.26.2) and the base image alpine to 3.23. Also required updating golangci-lint to a newer version, migrating its settings, and fixing various minor const issues.